### PR TITLE
Use semver to indicate acceptance of minor version upgrades for guzzle and uuid

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     },
     "require": {
         "php": ">=5.6",
-        "guzzlehttp/guzzle": "6.2.1",
-        "ramsey/uuid": "3.5.0",
+        "guzzlehttp/guzzle": "^6.2.1",
+        "ramsey/uuid": "^3.5.0",
         "psr/log": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
I'm trying to install this in a project where another, existing dependency has locked guzzle at 6.2.3. Using semver to indicate that minor version upgrades are acceptable will allow intacct-sdk-php to install