### PR TITLE
Test against PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 before_script:
   - composer self-update

--- a/test/Intacct/Functions/AbstractFunctionTest.php
+++ b/test/Intacct/Functions/AbstractFunctionTest.php
@@ -30,7 +30,7 @@ class AbstractFunctionTest extends \PHPUnit\Framework\TestCase
 
     public function setUp()
     {
-        $this->object = $this->getMockForAbstractClass(AbstractFunction::class);
+        $this->object = @$this->getMockForAbstractClass(AbstractFunction::class);
     }
 
     public function testValidControlId()


### PR DESCRIPTION
It would be great to have this SDK tested against PHP 7.4. I've updated the Travis config towards this end.

Also the mocking feature in PHPUnit 5 triggers a deprecation notice in 7.4. I've suppressed this particular line in the test suite.