### PR TITLE
Fix bug when journal entry amount is 0

### DIFF
--- a/src/Intacct/Functions/GeneralLedger/AbstractJournalEntryLine.php
+++ b/src/Intacct/Functions/GeneralLedger/AbstractJournalEntryLine.php
@@ -19,6 +19,11 @@ namespace Intacct\Functions\GeneralLedger;
 
 abstract class AbstractJournalEntryLine extends AbstractGlEntry
 {
+    /** @var string */
+    const TR_TYPE_CREDIT = -1;
+
+    /** @var string */
+    const TR_TYPE_DEBIT = 1;
 
     /** @var string */
     protected $glAccountNumber;
@@ -37,6 +42,9 @@ abstract class AbstractJournalEntryLine extends AbstractGlEntry
 
     /** @var string */
     protected $exchangeRateType;
+
+    /** @var string */
+    protected $transactionType;
 
     /**
      * @return string
@@ -132,5 +140,21 @@ abstract class AbstractJournalEntryLine extends AbstractGlEntry
     public function setExchangeRateType($exchangeRateType)
     {
         $this->exchangeRateType = $exchangeRateType;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTransactionType()
+    {
+        return $this->transactionType;
+    }
+
+    /**
+     * @param string $transactionType
+     */
+    public function setTransactionType($transactionType)
+    {
+        $this->transactionType = $transactionType;
     }
 }

--- a/src/Intacct/Functions/GeneralLedger/JournalEntryLineCreate.php
+++ b/src/Intacct/Functions/GeneralLedger/JournalEntryLineCreate.php
@@ -36,7 +36,13 @@ class JournalEntryLineCreate extends AbstractJournalEntryLine
 
         $xml->writeElement('DOCUMENT', $this->getDocumentNumber());
         $xml->writeElement('ACCOUNTNO', $this->getGlAccountNumber(), true);
-        if ($this->getTransactionAmount()< 0) {
+
+        // If the amount is 0, we need to explicitly specify whether the entry is Debit or Credit
+        if ($this->getTransactionAmount() == 0 && $this->getTransactionType()) {
+            $xml->writeElement('TR_TYPE', $this->getTransactionType());
+		    $xml->writeElement('TRX_AMOUNT', $this->getTransactionAmount(), true);
+        }
+        else if ($this->getTransactionAmount()< 0) {
             $xml->writeElement('TR_TYPE', '-1'); //Credit
             $xml->writeElement('TRX_AMOUNT', abs($this->getTransactionAmount()), true);
         } else {


### PR DESCRIPTION
A journal entry amount of "0" would always results in a transaction type of "Debit". Add the ability to indicate which journal entry is Debit and which is Credit when journaling an amount of "0".