### PR TITLE
feature(ClientConfig): Allow setting Guzzle's handler

### DIFF
--- a/src/Intacct/ClientConfig.php
+++ b/src/Intacct/ClientConfig.php
@@ -18,6 +18,7 @@
 namespace Intacct;
 
 use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
 use Intacct\Credentials\CredentialsInterface;
 use Intacct\Logging\MessageFormatter;
 use Psr\Log\LoggerInterface;
@@ -330,23 +331,25 @@ class ClientConfig
         $this->logMessageFormatter = $logMessageFormatter;
     }
 
-    /** @var MockHandler */
-    private $mockHandler;
+    /**
+     * @var HandlerStack
+     */
+    private $requestHandler;
 
     /**
-     * @return MockHandler
+     * @return HandlerStack
      */
-    public function getMockHandler()
+    public function getRequestHandler() : HandlerStack
     {
-        return $this->mockHandler;
+        return $this->requestHandler;
     }
 
     /**
-     * @param MockHandler $mockHandler
+     * @param HandlerStack $requestHandler
      */
-    public function setMockHandler(MockHandler $mockHandler)
+    public function setRequestHandler(HandlerStack $requestHandler)
     {
-        $this->mockHandler = $mockHandler;
+        $this->requestHandler = $requestHandler;
     }
 
     /**

--- a/test/Intacct/OfflineClientTest.php
+++ b/test/Intacct/OfflineClientTest.php
@@ -17,6 +17,7 @@
 
 namespace Intacct;
 
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Handler\MockHandler;
 use Intacct\Functions\Company\ApiSessionCreate;
@@ -56,7 +57,7 @@ EOF;
         $clientConfig->setSenderId('testsender');
         $clientConfig->setSenderPassword('testsendpass');
         $clientConfig->setSessionId('testsession..');
-        $clientConfig->setMockHandler($mock);
+        $clientConfig->setRequestHandler(HandlerStack::create($mock));
 
         $requestConfig = new RequestConfig();
         $requestConfig->setPolicyId('asyncPolicyId');
@@ -97,7 +98,7 @@ EOF;
         $clientConfig->setSenderId('testsender');
         $clientConfig->setSenderPassword('testsendpass');
         $clientConfig->setSessionId('testsession..');
-        $clientConfig->setMockHandler($mock);
+        $clientConfig->setRequestHandler(HandlerStack::create($mock));
 
         $requestConfig = new RequestConfig();
         $requestConfig->setPolicyId('asyncPolicyId');

--- a/test/Intacct/OnlineClientTest.php
+++ b/test/Intacct/OnlineClientTest.php
@@ -17,6 +17,7 @@
 
 namespace Intacct;
 
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Handler\MockHandler;
 use Intacct\Functions\Company\ApiSessionCreate;
@@ -77,7 +78,7 @@ EOF;
         $clientConfig->setSenderId('testsender');
         $clientConfig->setSenderPassword('testsendpass');
         $clientConfig->setSessionId('testsession..');
-        $clientConfig->setMockHandler($mock);
+        $clientConfig->setRequestHandler(HandlerStack::create($mock));
 
         $client = new OnlineClient($clientConfig);
 
@@ -137,7 +138,7 @@ EOF;
         $clientConfig->setSenderId('testsender');
         $clientConfig->setSenderPassword('testsendpass');
         $clientConfig->setSessionId('testsession..');
-        $clientConfig->setMockHandler($mock);
+        $clientConfig->setRequestHandler(HandlerStack::create($mock));
 
         $client = new OnlineClient($clientConfig);
 
@@ -214,7 +215,7 @@ EOF;
         $clientConfig->setSenderId('testsender');
         $clientConfig->setSenderPassword('testsendpass');
         $clientConfig->setSessionId('testsession..');
-        $clientConfig->setMockHandler($mock);
+        $clientConfig->setRequestHandler(HandlerStack::create($mock));
 
         $client = new OnlineClient($clientConfig);
 
@@ -279,7 +280,7 @@ EOF;
         $clientConfig->setSenderId('testsender');
         $clientConfig->setSenderPassword('testsendpass');
         $clientConfig->setSessionId('testsession..');
-        $clientConfig->setMockHandler($mock);
+        $clientConfig->setRequestHandler(HandlerStack::create($mock));
         $clientConfig->setLogger($logger);
 
         $client = new OnlineClient($clientConfig);

--- a/test/Intacct/SessionProviderTest.php
+++ b/test/Intacct/SessionProviderTest.php
@@ -17,6 +17,7 @@
 
 namespace Intacct;
 
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Handler\MockHandler;
 
@@ -75,7 +76,7 @@ EOF;
         $config->setCompanyId('testcompany');
         $config->setUserId('testuser');
         $config->setUserPassword('testpass');
-        $config->setMockHandler($mock);
+        $config->setRequestHandler(HandlerStack::create($mock));
 
         $sessionCreds = SessionProvider::factory($config);
 
@@ -136,7 +137,7 @@ EOF;
         $config->setEntityId('testentity');
         $config->setUserId('testuser');
         $config->setUserPassword('testpass');
-        $config->setMockHandler($mock);
+        $config->setRequestHandler(HandlerStack::create($mock));
 
         $sessionCreds = SessionProvider::factory($config);
 
@@ -195,7 +196,7 @@ EOF;
         $config->setSenderPassword('pass123!');
         $config->setSessionId('fAkESesSiOnId..');
         $config->setEndpointUrl('https://unittest.intacct.com/ia/xml/xmlgw.phtml');
-        $config->setMockHandler($mock);
+        $config->setRequestHandler(HandlerStack::create($mock));
 
         $sessionCreds = SessionProvider::factory($config);
 
@@ -258,7 +259,7 @@ EOF;
         $config->setSessionId('fAkESesSiOnId..');
         $config->setEntityId('testentity');
         $config->setEndpointUrl('https://unittest.intacct.com/ia/xml/xmlgw.phtml');
-        $config->setMockHandler($mock);
+        $config->setRequestHandler(HandlerStack::create($mock));
 
         $sessionCreds = SessionProvider::factory($config);
 
@@ -321,7 +322,7 @@ EOF;
         $config->setSessionId('EntityAsession..');
         $config->setEntityId('entityB');
         $config->setEndpointUrl('https://unittest.intacct.com/ia/xml/xmlgw.phtml');
-        $config->setMockHandler($mock);
+        $config->setRequestHandler(HandlerStack::create($mock));
 
         $sessionCreds = SessionProvider::factory($config);
 
@@ -385,7 +386,7 @@ EOF;
         $config = new ClientConfig();
         $config->setSessionId('fAkESesSiOnId..');
         $config->setEndpointUrl('https://unittest.intacct.com/ia/xml/xmlgw.phtml');
-        $config->setMockHandler($mock);
+        $config->setRequestHandler(HandlerStack::create($mock));
 
         $sessionCreds = SessionProvider::factory($config);
 

--- a/test/Intacct/Xml/RequestHandlerTest.php
+++ b/test/Intacct/Xml/RequestHandlerTest.php
@@ -18,6 +18,7 @@
 
 namespace Intacct\Xml;
 
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Handler\MockHandler;
 use Intacct\ClientConfig;
@@ -81,7 +82,7 @@ EOF;
         $clientConfig->setSenderId('testsenderid');
         $clientConfig->setSenderPassword('pass123!');
         $clientConfig->setSessionId('testsession..');
-        $clientConfig->setMockHandler($mock);
+        $clientConfig->setRequestHandler(HandlerStack::create($mock));
 
         $requestConfig = new RequestConfig();
         $requestConfig->setControlId('unittest');
@@ -127,7 +128,7 @@ EOF;
         $clientConfig->setCompanyId('testcompany');
         $clientConfig->setUserId('testuser');
         $clientConfig->setUserPassword('testpass');
-        $clientConfig->setMockHandler($mock);
+        $clientConfig->setRequestHandler(HandlerStack::create($mock));
 
         $requestConfig = new RequestConfig();
         $requestConfig->setControlId('requestUnitTest');
@@ -204,7 +205,7 @@ EOF;
         $headers = [
             'Content-Type' => 'text/xml; encoding="UTF-8"',
         ];
-        
+
         $mock = new MockHandler([
             new Response(502),
             new Response(200, $headers, $xml),
@@ -214,7 +215,7 @@ EOF;
         $clientConfig->setSenderId('testsenderid');
         $clientConfig->setSenderPassword('pass123!');
         $clientConfig->setSessionId('testsession..');
-        $clientConfig->setMockHandler($mock);
+        $clientConfig->setRequestHandler(HandlerStack::create($mock));
 
         $requestConfig = new RequestConfig();
 
@@ -263,7 +264,7 @@ EOF;
         $clientConfig->setCompanyId('badcompany');
         $clientConfig->setUserId('baduser');
         $clientConfig->setUserPassword('badpass');
-        $clientConfig->setMockHandler($mock);
+        $clientConfig->setRequestHandler(HandlerStack::create($mock));
 
         $requestConfig = new RequestConfig();
 
@@ -292,7 +293,7 @@ EOF;
         $clientConfig->setSenderId('testsenderid');
         $clientConfig->setSenderPassword('pass123!');
         $clientConfig->setSessionId('testsession..');
-        $clientConfig->setMockHandler($mock);
+        $clientConfig->setRequestHandler(HandlerStack::create($mock));
 
         $requestConfig = new RequestConfig();
 
@@ -316,7 +317,7 @@ EOF;
         $clientConfig->setSenderId('testsenderid');
         $clientConfig->setSenderPassword('pass123!');
         $clientConfig->setSessionId('testsession..');
-        $clientConfig->setMockHandler($mock);
+        $clientConfig->setRequestHandler(HandlerStack::create($mock));
 
         $requestConfig = new RequestConfig();
 
@@ -381,7 +382,7 @@ EOF;
         $clientConfig->setSenderId('testsenderid');
         $clientConfig->setSenderPassword('pass123!');
         $clientConfig->setSessionId('testsession..');
-        $clientConfig->setMockHandler($mock);
+        $clientConfig->setRequestHandler(HandlerStack::create($mock));
         $clientConfig->setLogger($logger);
 
         $requestConfig = new RequestConfig();
@@ -432,7 +433,7 @@ EOF;
         $clientConfig->setSenderId('testsenderid');
         $clientConfig->setSenderPassword('pass123!');
         $clientConfig->setSessionId('testsession..');
-        $clientConfig->setMockHandler($mock);
+        $clientConfig->setRequestHandler(HandlerStack::create($mock));
         $clientConfig->setLogger($logger);
 
         $requestConfig = new RequestConfig();


### PR DESCRIPTION
Being able to set the handler is important for things like middleware, with this PR you can, and it's not specific to just the `MockHandler`, which is pointless outside of unit testing.